### PR TITLE
Bug 1476039 - add support for fake consumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,14 @@ client.on('connected', async (conn) => {
 });
 ```
 
+## Fakes for Testing
+
+The `FakeClient` class can be used instead of `Client` in testing situations,
+to avoid the need for an actual AMQP server.  The class itself has no
+functionality, but serves as a semaphore to activate a "fake" mode when passed
+to higher-level components such as `PulseConsumer`: `fakeConsumer =
+consume({client: new FakeClient(), ..})`.
+
 # PulseConsumer
 
 A PulseConsumer declares a queue and listens for messages on that queue,
@@ -291,6 +299,22 @@ still consuming.  Use `queue.withChannel` (above) for this purpose. In this
 case, it is simplest to provide an empty `bindings: []` to the PulseConsumer
 constructor and manage bindings entirely via `withChannel`. Note that with this
 arrangement, routing key reference is not supported.
+
+## Fake Mode
+
+If passed a `FakeClient`, `consume` will return a fake consumer.  That object
+does not interface with an AMQP server, but has an async `fakeMessage` method
+which will call back the message-handling function with the same arguments.
+
+```javascript
+const consumer = consume({
+  client: new FakeClient(),
+  ...
+}, async ({payload, exchange, routingKey, redelivered, routes, routing}) => {
+  // ...
+});
+await consumer.fakeMessage({payload: .., exchange: .., ..});
+```
 
 # Testing
 

--- a/src/client.js
+++ b/src/client.js
@@ -241,6 +241,18 @@ class Client extends events.EventEmitter {
 
 exports.Client = Client;
 
+/**
+ * A fake client is basically just a semaphore for users like PulseConsumer to
+ * invoke their own fakery.
+ */
+class FakeClient {
+  constructor() {
+    this.isFakeClient = true;
+  }
+}
+
+exports.FakeClient = FakeClient;
+
 let nextConnectionId = 1;
 
 /**

--- a/src/consumer.js
+++ b/src/consumer.js
@@ -1,3 +1,4 @@
+const debug = require('debug');
 const events = require('events');
 const amqplib = require('amqplib');
 const assert = require('assert');
@@ -238,7 +239,34 @@ class PulseConsumer extends events.EventEmitter {
   }
 }
 
+class FakePulseConsumer {
+  constructor(handleMessage) {
+    this.handleMessage = handleMessage;
+    this.debug = debug('FakePulseConsumer');
+  }
+
+  async stop() {
+    this.debug('stopping');
+    // do nothing
+  }
+
+  /**
+   * Inject a fake message.  This calls the supplied handleMessage
+   * function directly.
+   */
+  async fakeMessage(msg) {
+    this.debug(`injecting fake message ${JSON.stringify(msg)}`);
+    await this.handleMessage(msg);
+  }
+}
+
 const consume = async (options, handleMessage) => {
+  if (options.client.isFakeClient) {
+    const pq = new FakePulseConsumer(handleMessage);
+    options.client.pulseConsumer = pq;
+    return pq;
+  }
+
   const pq = new PulseConsumer(options, handleMessage);
   await pq._start();
   return pq;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
-const {Client} = require('./client');
+const {Client, FakeClient} = require('./client');
 const {consume} = require('./consumer');
 
 module.exports = {
   Client,
+  FakeClient,
   consume,
 };

--- a/test/consumer_test.js
+++ b/test/consumer_test.js
@@ -1,4 +1,4 @@
-const {Client, consume} = require('../src');
+const {FakeClient, Client, consume} = require('../src');
 const amqplib = require('amqplib');
 const assume = require('assume');
 const debugModule = require('debug');
@@ -134,5 +134,18 @@ suite('PulseConsumer', function() {
     }
     assert(false, 'Did not get expected error');
 
+  });
+});
+
+suite('FakePulseConsumer', function() {
+  test('consume messages', async function() {
+    const got = [];
+    const consumer = await consume({
+      client: new FakeClient,
+    }, messageInfo => got.push(messageInfo));
+
+    consumer.fakeMessage({payload: 'hi'});
+
+    assume(got).to.deeply.equal([{payload: 'hi'}]);
   });
 });


### PR DESCRIPTION
`FakePulseConsumer` just "consumes" the messages supplied by `fakeMessage`

I'm not especially happy with this "semaphore" idea, but it seems to work in cases where the client is created in tc-lib-loader (like in tc-stats-collector).