### PR TITLE
Bug 1471315 - add publishing support

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,14 +20,17 @@
   },
   "engineStrict": true,
   "devDependencies": {
-    "assume": "^1.5.2",
+    "assume": "^2.1.0",
     "eslint-config-taskcluster": "^3.1.0",
-    "mocha": "^5.0.0",
+    "mocha": "^5.2.0",
     "slugid": "^2.0.0",
-    "taskcluster-lib-monitor": "^5.1.5"
+    "taskcluster-lib-monitor": "^10.0.0",
+    "taskcluster-lib-testing": "^12.1.0",
+    "taskcluster-lib-validate": "^11.0.2"
   },
   "dependencies": {
     "amqplib": "^0.5.2",
-    "debug": "^3.1.0"
+    "debug": "^3.1.0",
+    "taskcluster-lib-urls": "^10.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,10 @@
 const {Client, FakeClient} = require('./client');
 const {consume} = require('./consumer');
+const {Exchanges} = require('./publisher');
 
 module.exports = {
   Client,
   FakeClient,
   consume,
+  Exchanges,
 };

--- a/src/publisher.js
+++ b/src/publisher.js
@@ -1,0 +1,436 @@
+const assert = require('assert');
+const libUrls = require('taskcluster-lib-urls');
+const debug = require('debug')('taskcluster-lib-pulse.publisher');
+const EventEmitter = require('events');
+
+class Exchanges {
+  constructor(options) {
+    assert(options.serviceName, 'serviceName is required');
+    assert(options.projectName, 'projectName is required');
+    assert(options.version, 'version is required');
+    assert(options.title, 'title is required');
+    assert(options.description, 'description is required');
+
+    Object.assign(this, options);
+    this.entries = [];
+
+    this.exchangePrefix = `exchange/${this.projectName}/${this.version}/`;
+  }
+
+  declare(entryOptions) {
+    const entry = new Entry({exchanges: this, ...entryOptions});
+    assert(!this.entries.some(e => e.name == entry.name),
+      `entry with name ${entry.name} already declared`);
+    assert(!this.entries.some(e => e.exchange == entry.exchange),
+      `entry with exchange ${entry.exchange} already declared`);
+    this.entries.push(entry);
+  }
+
+  reference() {
+    return {
+      version: 0,
+      $schema: 'http://schemas.taskcluster.net/base/v1/exchanges-reference.json#',
+      serviceName: this.serviceName,
+      title: this.title,
+      description: this.description,
+      exchangePrefix: this.exchangePrefix,
+      entries: this.entries.map(e => e.reference()),
+    };
+  }
+
+  async publisher({rootUrl, schemaset, client, sendDeadline, publish, aws}) {
+    let publisher;
+    if (client.isFakeClient) {
+      publisher = new FakePulsePublisher({rootUrl, schemaset, exchanges: this});
+    } else {
+      publisher = new PulsePublisher({rootUrl, schemaset, client, sendDeadline, exchanges: this});
+    }
+    if (publish) {
+      assert.equal(rootUrl, 'https://taskclutser.net',
+        'only taskcluster.net publishes references to S3');
+      assert(aws, 'aws is required to publish references to S3');
+      await publisher.publishReference(aws, this.reference());
+    }
+    await publisher._start();
+    return publisher;
+  }
+}
+
+exports.Exchanges = Exchanges;
+
+class Entry {
+  constructor({exchanges, ...options}) {
+    assert(options.exchange, 'exchange is required');
+    assert(options.name, 'name is required');
+    assert(options.title, 'title is required');
+    assert(options.description, 'description is required');
+    assert(options.schema, 'schema is required');
+    assert(options.routingKey, 'routingKey is required');
+    assert(options.messageBuilder, 'messageBuilder is required');
+    assert(options.routingKeyBuilder, 'routingKeyBuilder is required');
+    assert(options.CCBuilder, 'CCBuilder is required');
+
+    Object.assign(this, options);
+    this.exchanges = exchanges;
+
+    // perform this transformation once, to a URI relative to the service's schemas
+    this.schema = `${exchanges.version}/${this.schema.replace(/\.ya?ml$/, '.json#')}`;
+
+    this._validateRoutingKey();
+  }
+
+  /**
+   * Return the subset of the reference document for this entry
+   */
+  reference() {
+    return {
+      type: 'topic-exchange',
+      exchange: this.exchange,
+      name: this.name,
+      title: this.title,
+      description: this.description,
+      schema: this.schema,
+      routingKey: this.routingKey.map(key => ({
+        name: key.name,
+        summary: key.summary,
+        constant: !!key.constant,
+        multipleWords: key.multipleWords,
+        required: key.required,
+      })),
+    };
+  }
+
+  /**
+   * Check that the routing key configuration is valid
+   */
+  _validateRoutingKey() {
+    const keyNames = [];
+    let sizeLeft = 255;
+    let firstMultiWordKey = null;
+
+    assert(Array.isArray(this.routingKey), 'routingKey must be an Array');
+    for (let key of this.routingKey) {
+      // Check that the key name is unique
+      assert(keyNames.indexOf(key.name) === -1,
+        `Routing key entry named ${key.name} already exists`);
+      keyNames.push(key.name);
+
+      // Check that we have a summary
+      assert(typeof key.summary === 'string',
+        `summary of routingKey entry ${key.name} is required.`);
+
+      // Check that we only have one multipleWords key in the routing key. If we
+      // have more than one then we can't really parse the routing key
+      // automatically. And technically, there is probably little need for two
+      // multiple word routing key entries.
+      if (key.multipleWords) {
+        assert(firstMultiWordKey === null,
+          'Can\'t have two multipleWord entries in a routing key, ' +
+               'here we have both \'' + firstMultiWordKey + '\' and ' +
+               '\'' + key.name + '\'');
+        firstMultiWordKey = key.name;
+      }
+
+      if (key.constant) {
+        // Check that any constant is indeed a string
+        assert(typeof key.constant === 'string',
+          'constant must be a string, if provided');
+
+        // Set maxSize
+        if (!key.maxSize) {
+          key.maxSize = key.constant.length;
+        }
+      }
+
+      // Check that we have a maxSize
+      assert(typeof key.maxSize == 'number' && key.maxSize > 0,
+        `routingKey declaration ${key.name} must have maxSize > 0`);
+
+      // Check size left in routingKey space
+      if (sizeLeft != 255) {
+        sizeLeft -= 1; // Remove one for the joining dot
+      }
+      sizeLeft -= key.maxSize;
+      assert(sizeLeft >= 0, 'Combined routingKey cannot be larger than 255 ' +
+             'including joining dots');
+    }
+  }
+}
+
+class PulsePublisher {
+  constructor({rootUrl, schemaset, client, exchanges, sendDeadline}) {
+    this.rootUrl = rootUrl;
+    this.schemaset = schemaset;
+    this.client = client;
+    this.exchanges = exchanges;
+    this.sendDeadline = sendDeadline || 12000;
+
+    assert.equal(client.namespace, exchanges.projectName,
+      'client namespace must match projectName');
+
+    this._handleConnection = this._handleConnection.bind(this);
+  }
+
+  /**
+   * Start the publisher. This is essentially an async constructor.
+   */
+  async _start() {
+    this._setChannel(null);
+    this.client.onConnected(this._handleConnection);
+
+    await this._assertExchanges();
+    await this._declareMethods();
+  }
+
+  /**
+   * Set the current channel (or clear it, if null).
+   *
+   * This will ensure that this.channelPromise resolves to the
+   * current channel (if one exists) or to the next channel created.
+   */
+  _setChannel(channel) {
+    if (channel) {
+      this._channel = channel;
+      if (this._resolveChannelPromise) {
+        // notify any waiters..
+        this._resolveChannelPromise(channel);
+        this._resolveChannelPromise = null;
+      }
+      // and make a clean, resolved promise for the channel
+      this.channelPromise = Promise.resolve(channel);
+    } else {
+      // we now have no working channel, so clear everything
+      // and set up to resolve channelPromise when we get one
+      this._channel = null;
+      if (!this._resolveChannelPromise) {
+        this.channelPromise = new Promise(resolve => {
+          this._resolveChannelPromise = resolve;
+        });
+      }
+    }
+  }
+
+  /**
+   * Handle a connected event from the client
+   */
+  async _handleConnection(connection) {
+    try {
+      this._connection = connection;
+      const channel = await connection.amqp.createConfirmChannel();
+      debug('using new channel');
+      this._setChannel(channel);
+    } catch (err) {
+      this.client.monitor.reportError(err);
+      this._connection = null;
+      this._setChannel(null);
+      connection.failed();
+    }
+  }
+
+  /**
+   * Assert all exchanges on the AMQP server
+   */
+  async _assertExchanges() {
+    await this.client.withChannel(async chan => {
+      await Promise.all(this.exchanges.entries.map(async entry => {
+        const exchange = this.exchanges.exchangePrefix + entry.exchange;
+        debug(`asserting exchange ${exchange}`);
+        await chan.assertExchange(exchange, 'topic', {
+          durable: true,
+          internal: false,
+          autoDelete: false,
+        });
+      }));
+    });
+  }
+
+  /**
+   * Declare the publishing methods based on the exchagnes.declare(..) calls
+   * made earlier.
+   */
+  async _declareMethods() {
+    const validator = await this.schemaset.validator(this.rootUrl);
+
+    for (let entry of this.exchanges.entries) {
+      const exchange = this.exchanges.exchangePrefix + entry.exchange;
+
+      this[entry.name] = async (...args) => {
+        // Construct message and routing key from arguments
+        const message = entry.messageBuilder.apply(undefined, args);
+        this._validateMessage(
+          this.rootUrl,
+          this.exchanges.serviceName,
+          validator,
+          entry,
+          message);
+
+        const routingKey = this._routingKeyToString(
+          entry,
+          entry.routingKeyBuilder.apply(undefined, args));
+
+        const CCs = entry.CCBuilder.apply(undefined, args);
+        assert(CCs instanceof Array, 'CCBuilder must return an array');
+
+        // Serialize message to buffer
+        const payload = new Buffer(JSON.stringify(message), 'utf8');
+
+        await this._send(exchange, routingKey, payload, CCs);
+      };
+    }
+  }
+
+  async stop() {
+    this.client.removeListener(this._handleConnection);
+    this.channelPromise = Promise.reject(new Error('PulsePublisher is stopped'));
+  }
+
+  async _send(exchange, routingKey, payload, CCs) {
+
+    // channel.publish uses a callback (since we use a confirm channel). The docs
+    // specify that it also returns false if the write buffer is full -- but importantly
+    // it still buffers the message in this case, reflecting the behavior of
+    // https://nodejs.org/api/net.html#net_socket_write_data_encoding_callback
+    // Since we have no way to convey this information to callers, we ignore
+    // the returned boolean.
+
+    // calculate the time after which we will not start a new send operation
+    const deadline = new Date(new Date().getTime() + this.sendDeadline);
+    let lastError = null;
+    let tries = 0;
+
+    // retry repeatedly until deadline; this getes rate-limited by the Client's
+    // reconnection logic in the event of a server error
+    const retry = async () => {
+      while (new Date() < deadline) {
+        try {
+          const channel = await this.channelPromise;
+
+          debug('%s message on exchange %s, routing key %s',
+            tries++ ? 'Republishing' : 'Publishing', exchange, routingKey);
+          await new Promise((resolve, reject) => {
+            channel.publish(exchange, routingKey, payload, {
+              persistent:         true,
+              contentType:        'application/json',
+              contentEncoding:    'utf-8',
+              CC:                 CCs,
+            }, (err) => {
+              if (err) {
+                reject(err);
+              } else {
+                resolve();
+              }
+            });
+          });
+
+          return;
+        } catch (err) {
+          lastError = err;
+
+          // something went wrong, so mark the connection as failed and try
+          // again (waiting for a new channel in the process)
+          if (this._connection) {
+            this._connection.failed();
+          }
+          this._setChannel(null);
+        }
+      }
+    };
+
+    let deadlineTimeout;
+    const failAtDeadline = async () => {
+      await new Promise(resolve => {
+        deadlineTimeout = setTimeout(resolve, this.sendDeadline);
+      });
+      const err = lastError || new Error('PulsePublisher.sendDeadline exceeded');
+      err.retries = tries;
+      err.exchange = exchange;
+      err.routingKey = routingKey;
+      throw err;
+    };
+
+    await Promise.race([retry(), failAtDeadline()]);
+    clearTimeout(deadlineTimeout);
+  }
+
+  /**
+   * Validate a message against the schema for this entry
+   */
+  _validateMessage(rootUrl, serviceName, validator, entry, message) {
+    const schema = libUrls.schema(rootUrl, serviceName, entry.schema);
+    var err = validator(message, schema);
+    if (err) {
+      debug('Failed to validate message: %j against schema: %s, error: %j',
+        message, entry.schema, err);
+      throw new Error('Message validation failed. ' + err);
+    }
+  }
+
+  /**
+   * Given the result of entry.rouingKeyBuilder, create a routing key string
+   */
+  _routingKeyToString(entry, routingKey) {
+    return entry.routingKey.map(key => {
+      let word = routingKey[key.name];
+      if (key.constant) {
+        word = key.constant;
+      }
+      if (!key.required && (word === undefined || word === null)) {
+        word = '_';
+      }
+      // Convert numbers to strings
+      if (typeof word === 'number') {
+        word = word.toString();
+      }
+      assert(typeof word === 'string',
+        `non-string routingKey entry ${key.name}: ${word}`);
+      assert(word.length <= key.maxSize,
+        `routingKey word: ${word} for ${key.name} is longer than ${key.maxSize}`);
+      if (!key.multipleWords) {
+        assert(word.indexOf('.') === -1,
+          `routingKey ${key.name} value ${word} contains '.'`);
+      }
+      return word;
+    }).join('.');
+  }
+
+  /**
+   * Publish the reference to S3; this is only used in the taskcluster.net deployment
+   */
+  async publishReference(aws, reference) {
+    const {serviceName, version} = this.exchanges;
+    const refUrl = libUrls.exchangeReference('https://taskcluster.net', serviceName, version);
+    const {hostname, path} = url.parse(refUrl);
+
+    const s3 = new aws.S3(options.aws);
+    return s3.putObject({
+      Bucket:           hostname,
+      Key:              path.slice(1), // omit leading `/`
+      Body:             JSON.stringify(reference, undefined, 2),
+      ContentType:      'application/json',
+    }).promise();
+  }
+}
+
+class FakePulsePublisher extends EventEmitter {
+  constructor({rootUrl, schemaset, client, exchanges}) {
+    super();
+    this.rootUrl = rootUrl;
+    this.schemaset = schemaset;
+    this.exchanges = exchanges;
+
+    // bind a few methods from the real PulsePublisher here
+    this._declareMethods = PulsePublisher.prototype._declareMethods.bind(this);
+    this._validateMessage = PulsePublisher.prototype._validateMessage.bind(this);
+    this._routingKeyToString = PulsePublisher.prototype._routingKeyToString.bind(this);
+  }
+
+  async _start() {
+    // steal _declareMethods from the real PulsePublisher; the resulting
+    // methods will call our _send method
+    this._declareMethods();
+  }
+
+  async _send(exchange, routingKey, payload, CCs) {
+    this.emit('message', {exchange, routingKey, payload: JSON.parse(payload), CCs});
+  }
+}

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -14,41 +14,6 @@ if (!PULSE_CONNECTION_STRING) {
   console.log('see README.md for details');
 }
 
-suite('buildConnectionString', function() {
-  test('missing arguments are an error', function() {
-    assume(() => buildConnectionString({password: 'pw', hostname: 'h', vhost: 'v'}))
-      .throws(/username/);
-    assume(() => buildConnectionString({username: 'me', hostname: 'h', vhost: 'v'}))
-      .throws(/password/);
-    assume(() => buildConnectionString({username: 'me', password: 'pw', vhost: 'v'}))
-      .throws(/hostname/);
-    assume(() => buildConnectionString({username: 'me', password: 'pw', hostname: 'v'}))
-      .throws(/vhost/);
-  });
-
-  test('builds a connection string with given host', function() {
-    assert.equal(
-      buildConnectionString({
-        username: 'me',
-        password: 'letmein',
-        hostname: 'pulse.abc.com',
-        vhost: '/',
-      }),
-      'amqps://me:letmein@pulse.abc.com:5671/%2F');
-  });
-
-  test('builds a connection string with urlencoded values', function() {
-    assert.equal(
-      buildConnectionString({
-        username: 'ali-escaper:/@\\|()<>&',
-        password: 'bobby-tables:/@\\|()<>&',
-        hostname: 'pulse.abc.com',
-        vhost: '/',
-      }),
-      'amqps://ali-escaper:/@%5C%7C()%3C%3E&:bobby-tables:/@%5C%7C()%3C%3E&@pulse.abc.com:5671/%2F');
-  });
-});
-
 const connectionTests = connectionString => {
   // use a unique name for each test run, just to ensure nothing interferes
   const unique = new Date().getTime().toString();
@@ -61,7 +26,7 @@ const connectionTests = connectionString => {
   let monitor;
 
   setup(async function() {
-    monitor = await libMonitor({project: 'tests', mock: true});
+    monitor = await libMonitor({projectName: 'tests', mock: true});
   });
 
   // publish a message to the exchange using just amqplib, declaring the
@@ -321,9 +286,48 @@ const connectionTests = connectionString => {
   });
 };
 
-suite('Client', function() {
-  suite('constructor', async function() {
-    const monitor = await libMonitor({project: 'tests', mock: true});
+suite('client_test.js', function() {
+  suite('buildConnectionString', function() {
+    test('missing arguments are an error', function() {
+      assume(() => buildConnectionString({password: 'pw', hostname: 'h', vhost: 'v'}))
+        .throws(/username/);
+      assume(() => buildConnectionString({username: 'me', hostname: 'h', vhost: 'v'}))
+        .throws(/password/);
+      assume(() => buildConnectionString({username: 'me', password: 'pw', vhost: 'v'}))
+        .throws(/hostname/);
+      assume(() => buildConnectionString({username: 'me', password: 'pw', hostname: 'v'}))
+        .throws(/vhost/);
+    });
+
+    test('builds a connection string with given host', function() {
+      assert.equal(
+        buildConnectionString({
+          username: 'me',
+          password: 'letmein',
+          hostname: 'pulse.abc.com',
+          vhost: '/',
+        }),
+        'amqps://me:letmein@pulse.abc.com:5671/%2F');
+    });
+
+    test('builds a connection string with urlencoded values', function() {
+      assert.equal(
+        buildConnectionString({
+          username: 'ali-escaper:/@\\|()<>&',
+          password: 'bobby-tables:/@\\|()<>&',
+          hostname: 'pulse.abc.com',
+          vhost: '/',
+        }),
+        'amqps://ali-escaper:/@%5C%7C()%3C%3E&:bobby-tables:/@%5C%7C()%3C%3E&@pulse.abc.com:5671/%2F');
+    });
+  });
+
+  suite('Client', function() {
+    let monitor;
+    suiteSetup(async function() {
+      monitor = await libMonitor({projectName: 'tests', mock: true});
+    });
+
     test('rejects connectionString *and* username', function() {
       assume(() => new Client({username: 'me', connectionString: 'amqps://..', monitor}))
         .throws(/along with/);

--- a/test/consumer_test.js
+++ b/test/consumer_test.js
@@ -6,146 +6,148 @@ const libMonitor = require('taskcluster-lib-monitor');
 
 const PULSE_CONNECTION_STRING = process.env.PULSE_CONNECTION_STRING;
 
-suite('PulseConsumer', function() {
-  // use a unique name for each test run, just to ensure nothing interferes
-  const unique = new Date().getTime().toString();
-  const exchangeName = `exchanges/test/${unique}`;
-  const routingKey = 'greetings.earthling.foo.bar.bing';
-  const routingKeyReference = [
-    {name: 'verb'},
-    {name: 'object'},
-    {name: 'remainder', multipleWords: true},
-  ];
-  const debug = debugModule('test');
+suite('consumer_test.js', function() {
+  suite('PulseConsumer', function() {
+    // use a unique name for each test run, just to ensure nothing interferes
+    const unique = new Date().getTime().toString();
+    const exchangeName = `exchanges/test/${unique}`;
+    const routingKey = 'greetings.earthling.foo.bar.bing';
+    const routingKeyReference = [
+      {name: 'verb'},
+      {name: 'object'},
+      {name: 'remainder', multipleWords: true},
+    ];
+    const debug = debugModule('test');
 
-  suiteSetup(async function() {
-    if (!PULSE_CONNECTION_STRING) {
-      this.skip();
-      return;
-    }
-
-    // otherwise, set up the exchange
-    const conn = await amqplib.connect(PULSE_CONNECTION_STRING);
-    const chan = await conn.createChannel();
-    await chan.assertExchange(exchangeName, 'topic');
-    await chan.close();
-    await conn.close();
-  });
-
-  const publishMessages = async () => {
-    const conn = await amqplib.connect(PULSE_CONNECTION_STRING);
-    const chan = await conn.createChannel();
-
-    for (let i = 0; i < 10; i++) {
-      const message = new Buffer(JSON.stringify({data: 'Hello', i}));
-      debug(`publishing fake message ${i} to exchange ${exchangeName}`);
-      await chan.publish(exchangeName, routingKey, message);
-    }
-
-    await chan.close();
-    await conn.close();
-  };
-
-  test('consume messages', async function() {
-    const monitor = await libMonitor({project: 'tests', mock: true});
-    const client = new Client({
-      connectionString: PULSE_CONNECTION_STRING,
-      retirementDelay: 50,
-      minReconnectionInterval: 20,
-      monitor,
-    });
-    const got = [];
-
-    await new Promise(async (resolve, reject) => {
-      try {
-        const pq = await consume({
-          client,
-          queueName: unique,
-          bindings: [{
-            exchange: exchangeName,
-            routingKeyPattern: '#',
-            routingKeyReference,
-          }],
-          prefetch: 2,
-        }, async message => {
-          debug(`handling message ${message.payload.i}`);
-          // message three gets retried once and then discarded.
-          if (message.payload.i == 3) {
-            // inject an error to test retrying
-            throw new Error('uhoh');
-          }
-
-          // recycle the client after we've had a few messages, just for exercise.
-          // Note that we continue to process this message here
-          if (got.length == 4) {
-            client.recycle();
-          }
-          got.push(message);
-          if (got.length === 9) {
-            // stop the PulseConsumer first, to exercise that code
-            // (this isn't how pq.stop would normally be called!)
-            pq.stop().then(resolve, reject);
-          }
-        });
-
-        // queue is bound by now, so it's safe to send messages
-        await publishMessages();
-      } catch (err) {
-        reject(err);
+    suiteSetup(async function() {
+      if (!PULSE_CONNECTION_STRING) {
+        this.skip();
+        return;
       }
+
+      // otherwise, set up the exchange
+      const conn = await amqplib.connect(PULSE_CONNECTION_STRING);
+      const chan = await conn.createChannel();
+      await chan.assertExchange(exchangeName, 'topic');
+      await chan.close();
+      await conn.close();
     });
 
-    await client.stop();
+    const publishMessages = async () => {
+      const conn = await amqplib.connect(PULSE_CONNECTION_STRING);
+      const chan = await conn.createChannel();
 
-    got.forEach(msg => {
-      assume(msg.payload.data).to.deeply.equal('Hello');
-      assume(msg.exchange).to.equal(exchangeName);
-      assume(msg.routingKey).to.equal(routingKey);
-      assume(msg.routing).to.deeply.equal({
-        verb: 'greetings',
-        object: 'earthling',
-        remainder: 'foo.bar.bing',
+      for (let i = 0; i < 10; i++) {
+        const message = new Buffer(JSON.stringify({data: 'Hello', i}));
+        debug(`publishing fake message ${i} to exchange ${exchangeName}`);
+        await chan.publish(exchangeName, routingKey, message);
+      }
+
+      await chan.close();
+      await conn.close();
+    };
+
+    test('consume messages', async function() {
+      const monitor = await libMonitor({projectName: 'tests', mock: true});
+      const client = new Client({
+        connectionString: PULSE_CONNECTION_STRING,
+        retirementDelay: 50,
+        minReconnectionInterval: 20,
+        monitor,
       });
-      // note that we ignore redelivered: some of these may be redelivered
-      // when the connection is recycled..
-      assume(msg.routes).to.deeply.equal([]);
-    });
+      const got = [];
 
-    const numbers = got.map(msg => msg.payload.i);
-    numbers.sort(); // with prefetch, order is not guaranteed
-    assume(numbers).to.deeply.equal([0, 1, 2, 4, 5, 6, 7, 8, 9]);
-  });
+      await new Promise(async (resolve, reject) => {
+        try {
+          const pq = await consume({
+            client,
+            queueName: unique,
+            bindings: [{
+              exchange: exchangeName,
+              routingKeyPattern: '#',
+              routingKeyReference,
+            }],
+            prefetch: 2,
+          }, async message => {
+            debug(`handling message ${message.payload.i}`);
+            // message three gets retried once and then discarded.
+            if (message.payload.i == 3) {
+              // inject an error to test retrying
+              throw new Error('uhoh');
+            }
 
-  test('no queueuName is an error', async function() {
-    const monitor = await libMonitor({project: 'tests', mock: true});
-    const client = new Client({
-      connectionString: PULSE_CONNECTION_STRING,
-      retirementDelay: 50,
-      minReconnectionInterval: 20,
-      monitor,
-    });
+            // recycle the client after we've had a few messages, just for exercise.
+            // Note that we continue to process this message here
+            if (got.length == 4) {
+              client.recycle();
+            }
+            got.push(message);
+            if (got.length === 9) {
+              // stop the PulseConsumer first, to exercise that code
+              // (this isn't how pq.stop would normally be called!)
+              pq.stop().then(resolve, reject);
+            }
+          });
 
-    try {
-      await consume({client, bindings: []}, () => {});
-    } catch (err) {
-      assume(err).to.match(/Must pass a queueName/);
+          // queue is bound by now, so it's safe to send messages
+          await publishMessages();
+        } catch (err) {
+          reject(err);
+        }
+      });
+
       await client.stop();
-      return;
-    }
-    assert(false, 'Did not get expected error');
 
+      got.forEach(msg => {
+        assume(msg.payload.data).to.deeply.equal('Hello');
+        assume(msg.exchange).to.equal(exchangeName);
+        assume(msg.routingKey).to.equal(routingKey);
+        assume(msg.routing).to.deeply.equal({
+          verb: 'greetings',
+          object: 'earthling',
+          remainder: 'foo.bar.bing',
+        });
+        // note that we ignore redelivered: some of these may be redelivered
+        // when the connection is recycled..
+        assume(msg.routes).to.deeply.equal([]);
+      });
+
+      const numbers = got.map(msg => msg.payload.i);
+      numbers.sort(); // with prefetch, order is not guaranteed
+      assume(numbers).to.deeply.equal([0, 1, 2, 4, 5, 6, 7, 8, 9]);
+    });
+
+    test('no queueuName is an error', async function() {
+      const monitor = await libMonitor({projectName: 'tests', mock: true});
+      const client = new Client({
+        connectionString: PULSE_CONNECTION_STRING,
+        retirementDelay: 50,
+        minReconnectionInterval: 20,
+        monitor,
+      });
+
+      try {
+        await consume({client, bindings: []}, () => {});
+      } catch (err) {
+        assume(err).to.match(/Must pass a queueName/);
+        await client.stop();
+        return;
+      }
+      assert(false, 'Did not get expected error');
+
+    });
   });
-});
 
-suite('FakePulseConsumer', function() {
-  test('consume messages', async function() {
-    const got = [];
-    const consumer = await consume({
-      client: new FakeClient,
-    }, messageInfo => got.push(messageInfo));
+  suite('FakePulseConsumer', function() {
+    test('consume messages', async function() {
+      const got = [];
+      const consumer = await consume({
+        client: new FakeClient,
+      }, messageInfo => got.push(messageInfo));
 
-    consumer.fakeMessage({payload: 'hi'});
+      consumer.fakeMessage({payload: 'hi'});
 
-    assume(got).to.deeply.equal([{payload: 'hi'}]);
+      assume(got).to.deeply.equal([{payload: 'hi'}]);
+    });
   });
 });

--- a/test/publisher_test.js
+++ b/test/publisher_test.js
@@ -1,0 +1,287 @@
+const {FakeClient, Client, Exchanges} = require('../src');
+const path = require('path');
+const amqplib = require('amqplib');
+const assume = require('assume');
+const assert = require('assert');
+const libMonitor = require('taskcluster-lib-monitor');
+const SchemaSet = require('taskcluster-lib-validate');
+const libUrls = require('taskcluster-lib-urls');
+const libTesting = require('taskcluster-lib-testing');
+
+const PULSE_CONNECTION_STRING = process.env.PULSE_CONNECTION_STRING;
+
+suite('publisher_test.js', function() {
+  const exchangeOptions = {
+    serviceName: 'lib-pulse',
+    projectName: 'taskcluster-lib-pulse',
+    version: 'v2',
+    title: 'tc-lib-pulse tests',
+    description: 'testing stuff',
+  };
+
+  const declaration = {
+    exchange: 'egg-hatched',
+    name: 'eggHatched',
+    title: 'Egg Hatched',
+    description: 'an egg hatched',
+    schema: 'egg-hatched-message.yml',
+    routingKey: [{
+      name:           'eggId',
+      summary:        'Identifier that we use for testing',
+      multipleWords:  false,
+      required:       true,
+      maxSize:        22,
+    }],
+    messageBuilder: msg => msg,
+    routingKeyBuilder: msg => msg,
+    CCBuilder: msg => [],
+  };
+
+  suite('Exchanges', function() {
+    test('constructor args required', function() {
+      assume(() => new Exchanges({})).to.throw(/is required/);
+    });
+
+    test('declare args required', function() {
+      const exchanges = new Exchanges(exchangeOptions);
+      assume(() => exchanges.declare({})).to.throw(/is required/);
+    });
+
+    test('declare routing key args required', function() {
+      const exchanges = new Exchanges(exchangeOptions);
+      assume(() => exchanges.declare({...declaration, routingKey: [{}]}))
+        .to.throw(/is required/);
+    });
+
+    test('declare routing key too long fails', function() {
+      const exchanges = new Exchanges(exchangeOptions);
+      const routingKey = [
+        {
+          name:           'testId',
+          summary:        'Identifier that we use for testing',
+          multipleWords:  false,
+          required:       true,
+          maxSize:        22,
+        }, {
+          name:           'taskRoutingKey',
+          summary:        'Test specific routing-key: `test.key`',
+          multipleWords:  true,
+          required:       true,
+          maxSize:        128,
+        }, {
+          name:           'state',
+          summary:        'State of something',
+          multipleWords:  false,
+          required:       false,
+          maxSize:        128,
+        },
+      ];
+      assume(() => exchanges.declare({...declaration, routingKey}))
+        .to.throw(/cannot be larger than/);
+    });
+
+    test('declaration with same name fails', function() {
+      const exchanges = new Exchanges(exchangeOptions);
+      exchanges.declare({...declaration, name: 'x', exchange: 'xx'});
+      assume(() => exchanges.declare({...declaration, name: 'x', exchange: 'yy'}))
+        .to.throw(/already declared/);
+    });
+
+    test('declaration with same exchange fails', function() {
+      const exchanges = new Exchanges(exchangeOptions);
+      exchanges.declare({...declaration, name: 'x', exchange: 'xx'});
+      assume(() => exchanges.declare({...declaration, name: 'y', exchange: 'xx'}))
+        .to.throw(/already declared/);
+    });
+
+    test('sucessful declaration', function() {
+      const exchanges = new Exchanges(exchangeOptions);
+      exchanges.declare(declaration);
+      // doesn't throw anything..
+    });
+
+    test('reference is correct', function() {
+      const exchanges = new Exchanges(exchangeOptions);
+      exchanges.declare(declaration);
+      assume(exchanges.reference()).to.deeply.equal({
+        $schema: 'http://schemas.taskcluster.net/base/v1/exchanges-reference.json#',
+        version: 0,
+        exchangePrefix: 'exchange/taskcluster-lib-pulse/v2/',
+        serviceName: 'lib-pulse',
+        title: 'tc-lib-pulse tests',
+        description: 'testing stuff',
+        entries: [{
+          description: 'an egg hatched',
+          exchange: 'egg-hatched',
+          name: 'eggHatched',
+          routingKey: [{
+            constant: false,
+            multipleWords: false,
+            name: 'eggId',
+            required: true,
+            summary: 'Identifier that we use for testing',
+          }],
+          schema: 'v2/egg-hatched-message.json#',
+          title: 'Egg Hatched',
+          type: 'topic-exchange',
+        }],
+      });
+    });
+  });
+
+  suite('PulsePublisher', function() {
+    // use a unique name for each test run, just to ensure nothing interferes
+    const unique = `test-${new Date().getTime()}`;
+    let client, conn, chan, exchanges, schemaset, publisher, messages;
+
+    suiteSetup(async function() {
+      if (!PULSE_CONNECTION_STRING) {
+        this.skip();
+        return;
+      }
+
+      const monitor = await libMonitor({projectName: exchangeOptions.projectName, mock: true});
+      client = new Client({
+        connectionString: PULSE_CONNECTION_STRING,
+        retirementDelay: 50,
+        minReconnectionInterval: 20,
+        monitor,
+      });
+      // this won't be necessary when namespace is a proper argument to the
+      // Client class..
+      client.namespace = exchangeOptions.projectName;
+
+      exchanges = new Exchanges(exchangeOptions);
+      exchanges.declare({...declaration, exchange: unique});
+
+      schemaset = new SchemaSet({
+        serviceName: exchangeOptions.serviceName,
+        folder: path.join(__dirname, 'schemas'),
+      });
+
+      publisher = await exchanges.publisher({
+        rootUrl: libUrls.testRootUrl(),
+        schemaset,
+        client,
+      });
+
+      // otherwise, set up a queue to listen for messages, using amqplib
+      // directly to avoid assuming the test subject works
+      conn = await amqplib.connect(PULSE_CONNECTION_STRING);
+      chan = await conn.createChannel();
+      const queueName = `queue/${client.namespace}/${unique}`;
+      await chan.assertQueue(queueName, 'topic', {
+        exclusive: true,
+        durable: false,
+        autodelete: true,
+      });
+
+      const exchangeName = `exchange/${client.namespace}/v2/${unique}`;
+      await chan.bindQueue(queueName, exchangeName, '#');
+      await chan.consume(queueName, msg => {
+        messages.push(msg);
+        chan.ack(msg);
+      });
+    });
+
+    setup(function() {
+      messages = [];
+    });
+
+    test('invalid message fails', async function() {
+      await assume(publisher.eggHatched({bogusThing: 'uhoh'}))
+        .rejects();
+    });
+
+    test('message with too-long routingKey fails', async function() {
+      await assume(publisher.eggHatched({eggId: 'uhoh! '.repeat(100)}))
+        .rejects();
+    });
+
+    test('publish a message', async function() {
+      await publisher.eggHatched({eggId: 'yolks-on-you'});
+
+      await libTesting.poll(async () => {
+        assert.equal(messages.length, 1);
+        const got = messages[0];
+        assert.equal(got.fields.routingKey, 'yolks-on-you');
+        assert.equal(got.fields.exchange, `exchange/${client.namespace}/v2/${unique}`);
+        assert.deepEqual(JSON.parse(got.content), {eggId: 'yolks-on-you'});
+      });
+    });
+
+    test('publish *lots* of messages in parallel', async function() {
+      this.slow(5000);
+
+      // this is enough messages to fill the amqplib write buffer..
+      const eggIds = [...Array(10000).keys()].map(id => id.toString());
+      await Promise.all(eggIds.map(eggId => publisher.eggHatched({eggId})));
+
+      await libTesting.poll(async () => {
+        const got = messages.map(msg => msg.fields.routingKey);
+        assert.deepEqual(got.length, eggIds.length, 'got expected number of messages');
+        assert.deepEqual(got.sort(), eggIds.sort(), 'got exactly the expected messages');
+      });
+    });
+
+    test('publish messages in parallel (with failed connections)', async function() {
+      await Promise.all(['a', 'b', 'c'].map(eggId => publisher.eggHatched({eggId})));
+      client.connections[0].amqp.close(); // force closure..
+      await Promise.all(['i', 'j', 'k', 'l', 'm'].map(eggId => publisher.eggHatched({eggId})));
+      client.connections[0].amqp.close(); // force closure..
+      await Promise.all(['x', 'y', 'z'].map(eggId => publisher.eggHatched({eggId})));
+
+      await libTesting.poll(async () => {
+        const got = messages.map(msg => msg.fields.routingKey).sort();
+        assert.deepEqual(got, ['a', 'b', 'c', 'i', 'j', 'k', 'l', 'm', 'x', 'y', 'z']);
+      });
+    });
+
+    suiteTeardown(async function() {
+      if (!PULSE_CONNECTION_STRING) {
+        return;
+      }
+
+      await client.stop();
+      await chan.close();
+      await conn.close();
+    });
+  });
+
+  suite('FakePulsePublisher', function() {
+    let client, exchanges, schemaset, publisher;
+
+    suiteSetup(async function() {
+      client = new FakeClient();
+      // this won't be necessary when namespace is a proper argument to the
+      // FakeClient class..
+      client.namespace = exchangeOptions.projectName;
+
+      exchanges = new Exchanges(exchangeOptions);
+      exchanges.declare({...declaration});
+
+      schemaset = new SchemaSet({
+        serviceName: exchangeOptions.serviceName,
+        folder: path.join(__dirname, 'schemas'),
+      });
+
+      publisher = await exchanges.publisher({
+        rootUrl: libUrls.testRootUrl(),
+        schemaset,
+        client,
+      });
+    });
+
+    test('fake publishing', async function() {
+      const messages = [];
+      publisher.on('message', msg => messages.push(msg));
+      await publisher.eggHatched({eggId: 'badEgg'});
+      assume(messages).to.deeply.equal([{
+        exchange: 'exchange/taskcluster-lib-pulse/v2/egg-hatched',
+        routingKey: 'badEgg',
+        payload: {eggId: 'badEgg'},
+        CCs: [],
+      }]);
+    });
+  });
+});

--- a/test/schemas/v2/egg-hatched-message.yml
+++ b/test/schemas/v2/egg-hatched-message.yml
@@ -1,0 +1,6 @@
+$schema:  http://json-schema.org/draft-06/schema#
+type:                     object
+properties:
+  eggId:
+    type:                 string
+additionalProperties:     false

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+accepts@~1.3.4:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.5.tgz#eb777df6011723a3b14e8a72c0805c8e86746bd2"
+  dependencies:
+    mime-types "~2.1.18"
+    negotiator "0.6.1"
+
 acorn-jsx@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
@@ -12,15 +19,15 @@ acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^5.4.0:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.4.1.tgz#fdc58d9d17f4a4e98d102ded826a9b9759125102"
+acorn@^5.5.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
 
 ajv-keywords@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
 
-ajv@^5.2.3, ajv@^5.3.0:
+ajv@^5.1.0, ajv@^5.2.3, ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
   dependencies:
@@ -28,6 +35,15 @@ ajv@^5.2.3, ajv@^5.3.0:
     fast-deep-equal "^1.0.0"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
+
+ajv@^6.5.0:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.2.tgz#678495f9b82f7cca6be248dd92f59bff5e1f4360"
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.1"
 
 amqplib@^0.5.1, amqplib@^0.5.2:
   version "0.5.2"
@@ -40,8 +56,8 @@ amqplib@^0.5.1, amqplib@^0.5.2:
     safe-buffer "^5.0.1"
 
 ansi-escapes@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.0.0.tgz#ec3e8b4e9f8064fc02c3ac9b65f1c275bda8ef92"
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -55,17 +71,25 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   dependencies:
     color-convert "^1.9.0"
 
+app-root-dir@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/app-root-dir/-/app-root-dir-1.0.2.tgz#38187ec2dea7577fff033ffcb12172692ff6e118"
+
 argparse@^1.0.7:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86"
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   dependencies:
     sprintf-js "~1.0.2"
+
+array-flatten@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
 
 array-union@^1.0.1:
   version "1.0.2"
@@ -85,33 +109,69 @@ asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
-assume@^1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/assume/-/assume-1.5.2.tgz#057c5a2f33ce7d1ccd8d783db2d5d098cacdd111"
+asn1@~0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
+
+assert-plus@1.0.0, assert-plus@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
+
+assertion-error@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+
+assume@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/assume/-/assume-2.1.0.tgz#16939464de8a4bfdfe3d5ab5256c5ae08a1ddf62"
   dependencies:
-    deep-eql "0.1.x"
-    fn.name "1.0.x"
-    object-inspect "1.0.x"
-    pathval "0.1.x"
-    pruddy-error "1.0.x"
+    deep-eql "^3.0.1"
+    fn.name "^1.0.1"
+    is-buffer "^2.0.0"
+    object-inspect "^1.5.0"
+    propget "^1.1.0"
+    pruddy-error "^2.0.2"
+
+async@^2.4.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
+  dependencies:
+    lodash "^4.17.10"
 
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
-aws-sdk@^2.30.0:
-  version "2.205.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.205.0.tgz#1a93730253e2be027a4bd3af9248cbda0573de80"
+aws-sdk@^2.142.0, aws-sdk@^2.144.0, aws-sdk@^2.30.0:
+  version "2.276.1"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.276.1.tgz#4f5cd52f4d1a13a412c8a8d75b276c556ad13947"
   dependencies:
     buffer "4.9.1"
-    events "^1.1.1"
+    events "1.1.1"
+    ieee754 "1.1.8"
     jmespath "0.15.0"
     querystring "0.2.0"
     sax "1.2.1"
     url "0.10.3"
     uuid "3.1.0"
-    xml2js "0.4.17"
-    xmlbuilder "4.2.1"
+    xml2js "0.4.19"
+
+aws-sign2@~0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
+
+aws4@^1.6.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
+
+azure-table-node@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/azure-table-node/-/azure-table-node-1.5.0.tgz#e798cfb96987b83c56da6e67b51f881825cde61b"
+  dependencies:
+    async "^2.4.0"
+    lodash "^4.17.4"
+    node-uuid "~1.4.1"
+    request "^2.81.0"
 
 babel-code-frame@^6.22.0:
   version "6.26.0"
@@ -121,28 +181,19 @@ babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-runtime@^6.0.0, babel-runtime@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.11.0"
-
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
 base64-js@^1.0.2:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.3.tgz#fb13668233d9614cf5fb4bce95a9ba4096cdf801"
-
-base64url@2.0.0, base64url@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/base64url/-/base64url-2.0.0.tgz#eac16e03ea1438eff9423d69baa36262ed1f70bb"
-
-bindings@1.x.x:
   version "1.3.0"
-  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
+
+bcrypt-pbkdf@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
+  dependencies:
+    tweetnacl "^0.14.3"
 
 bitsyntax@~0.0.4:
   version "0.0.4"
@@ -153,6 +204,33 @@ bitsyntax@~0.0.4:
 bluebird@^3.4.6, bluebird@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
+
+body-parser@1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.2.tgz#87678a19d84b47d859b83199bd59bce222b10454"
+  dependencies:
+    bytes "3.0.0"
+    content-type "~1.0.4"
+    debug "2.6.9"
+    depd "~1.1.1"
+    http-errors "~1.6.2"
+    iconv-lite "0.4.19"
+    on-finished "~2.3.0"
+    qs "6.5.1"
+    raw-body "2.3.2"
+    type-is "~1.6.15"
+
+boom@0.4.x:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/boom/-/boom-0.4.2.tgz#7a636e9ded4efcefb19cef4947a3c67dfaee911b"
+  dependencies:
+    hoek "0.9.x"
+
+boom@2.x.x:
+  version "2.10.1"
+  resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
+  dependencies:
+    hoek "2.x.x"
 
 boom@4.x.x:
   version "4.3.1"
@@ -167,19 +245,23 @@ boom@5.x.x:
     hoek "4.x.x"
 
 brace-expansion@^1.1.7:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-browser-stdout@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
+browser-stdout@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
 
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+
+buffer-from@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.0.tgz#87fcaa3a298358e0ade6e442cfce840740d1ad04"
 
 buffer-more-ints@0.0.2:
   version "0.0.2"
@@ -192,6 +274,10 @@ buffer@4.9.1:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
+
+bytes@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
 
 caller-path@^0.1.0:
   version "0.1.0"
@@ -207,6 +293,21 @@ capture-stack-trace@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz#4a6fa07399c26bba47f0b2496b4d0fb408c5550d"
 
+caseless@~0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
+
+chai@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.1.2.tgz#0f64584ba642f0f2ace2806279f4f06ca23ad73c"
+  dependencies:
+    assertion-error "^1.0.1"
+    check-error "^1.0.1"
+    deep-eql "^3.0.0"
+    get-func-name "^2.0.0"
+    pathval "^1.0.0"
+    type-detect "^4.0.0"
+
 chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -218,12 +319,12 @@ chalk@^1.1.3:
     supports-color "^2.0.0"
 
 chalk@^2.0.0, chalk@^2.1.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
-    ansi-styles "^3.1.0"
+    ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
-    supports-color "^4.0.0"
+    supports-color "^5.3.0"
 
 chardet@^0.4.0:
   version "0.4.2"
@@ -232,6 +333,10 @@ chardet@^0.4.0:
 charenc@~0.0.1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+
+check-error@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
 
 circular-json@^0.3.1:
   version "0.3.3"
@@ -252,24 +357,24 @@ co@^4.6.0:
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
 
 color-convert@^1.9.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.2.tgz#49881b8fba67df12a96bdf3f56c0aab9e7913147"
   dependencies:
-    color-name "^1.1.1"
+    color-name "1.1.1"
 
-color-name@^1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+color-name@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.1.tgz#4b1415304cf50028ea81643643bd82ea05803689"
 
-combined-stream@1.0.6:
+combined-stream@1.0.6, combined-stream@~1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.11.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
+commander@2.15.1:
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
 
 component-emitter@^1.2.0:
   version "1.2.1"
@@ -280,26 +385,35 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
 concat-stream@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   dependencies:
+    buffer-from "^1.0.0"
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
+
+content-disposition@0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
+
+content-type@~1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
+
+cookie-signature@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
 
 cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
 
 cookiejar@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.1.tgz#41ad57b1b555951ec171412a81942b1e8200d34a"
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
 
-core-js@^2.4.0:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
-
-core-util-is@~1.0.0:
+core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
@@ -321,11 +435,35 @@ crypt@~0.0.1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
 
+cryptiles@0.2.x:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-0.2.2.tgz#ed91ff1f17ad13d3748288594f8a48a0d26f325c"
+  dependencies:
+    boom "0.4.x"
+
+cryptiles@2.x.x:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
+  dependencies:
+    boom "2.x.x"
+
 cryptiles@3.x.x:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-3.1.2.tgz#a89fbb220f5ce25ec56e8c4aa8a4fd7b5b0d29fe"
   dependencies:
     boom "5.x.x"
+
+dashdash@^1.12.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
+  dependencies:
+    assert-plus "^1.0.0"
+
+debug@2.6.9, debug@^2.2.0:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  dependencies:
+    ms "2.0.0"
 
 debug@3.1.0, debug@^3.1.0:
   version "3.1.0"
@@ -333,17 +471,15 @@ debug@3.1.0, debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^2.2.0:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+deep-eql@^3.0.0, deep-eql@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
   dependencies:
-    ms "2.0.0"
+    type-detect "^4.0.0"
 
-deep-eql@0.1.x:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-0.1.3.tgz#ef558acab8de25206cd713906d74e56930eb69f2"
-  dependencies:
-    type-detect "0.1.1"
+deep-equal@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -365,9 +501,21 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
 
-diff@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.1.tgz#aa8567a6eed03c531fc89d3f711cd0e5259dec75"
+depd@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
+
+depd@~1.1.1, depd@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
+
+destroy@~1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
+
+diff@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
 doctrine@^2.1.0:
   version "2.1.0"
@@ -381,18 +529,35 @@ duplexer2@^0.1.4:
   dependencies:
     readable-stream "^2.0.2"
 
-ecdsa-sig-formatter@1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz#4bc926274ec3b5abb5016e7e1d60921ac262b2a1"
+ecc-jsbn@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
-    base64url "^2.0.0"
+    jsbn "~0.1.0"
+
+ecdsa-sig-formatter@1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz#1c595000f04a8897dfb85000892a0f4c33af86c3"
+  dependencies:
     safe-buffer "^5.0.1"
 
+ee-first@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+
+encodeurl@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
+
 error-ex@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
   dependencies:
     is-arrayish "^0.2.1"
+
+escape-html@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -405,8 +570,8 @@ eslint-config-taskcluster@^3.1.0:
     eslint "^4.10.0"
 
 eslint-scope@^3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.3.tgz#bb507200d3d17f60247636160b4826284b108535"
   dependencies:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
@@ -416,8 +581,8 @@ eslint-visitor-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
 eslint@^4.10.0:
-  version "4.17.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.17.0.tgz#dc24bb51ede48df629be7031c71d9dc0ee4f3ddf"
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.19.1.tgz#32d1d653e1d90408854bfb296f076ec7e186a300"
   dependencies:
     ajv "^5.3.0"
     babel-code-frame "^6.22.0"
@@ -428,7 +593,7 @@ eslint@^4.10.0:
     doctrine "^2.1.0"
     eslint-scope "^3.7.1"
     eslint-visitor-keys "^1.0.0"
-    espree "^3.5.2"
+    espree "^3.5.4"
     esquery "^1.0.0"
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
@@ -450,36 +615,36 @@ eslint@^4.10.0:
     path-is-inside "^1.0.2"
     pluralize "^7.0.0"
     progress "^2.0.0"
+    regexpp "^1.0.1"
     require-uncached "^1.0.3"
     semver "^5.3.0"
     strip-ansi "^4.0.0"
     strip-json-comments "~2.0.1"
-    table "^4.0.1"
+    table "4.0.2"
     text-table "~0.2.0"
 
-espree@^3.5.2:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.3.tgz#931e0af64e7fbbed26b050a29daad1fc64799fa6"
+espree@^3.5.4:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
   dependencies:
-    acorn "^5.4.0"
+    acorn "^5.5.0"
     acorn-jsx "^3.0.0"
 
 esprima@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
 
 esquery@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.0.tgz#cfba8b57d7fba93f17298a8a006a04cda13d80fa"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
   dependencies:
     estraverse "^4.0.0"
 
 esrecurse@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.0.tgz#fa9568d98d3823f9a41d91e902dcab9ea6e5b163"
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
   dependencies:
     estraverse "^4.1.0"
-    object-assign "^4.0.1"
 
 estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
   version "4.2.0"
@@ -489,25 +654,84 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
-events@^1.1.1:
+etag@~1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
+
+events@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
 
-extend@^3.0.0:
+express-sslify@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/express-sslify/-/express-sslify-1.2.0.tgz#30e84bceed1557eb187672bbe1430a0a2a100d9c"
+
+express@4.16.2:
+  version "4.16.2"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.16.2.tgz#e35c6dfe2d64b7dca0a5cd4f21781be3299e076c"
+  dependencies:
+    accepts "~1.3.4"
+    array-flatten "1.1.1"
+    body-parser "1.18.2"
+    content-disposition "0.5.2"
+    content-type "~1.0.4"
+    cookie "0.3.1"
+    cookie-signature "1.0.6"
+    debug "2.6.9"
+    depd "~1.1.1"
+    encodeurl "~1.0.1"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    finalhandler "1.1.0"
+    fresh "0.5.2"
+    merge-descriptors "1.0.1"
+    methods "~1.1.2"
+    on-finished "~2.3.0"
+    parseurl "~1.3.2"
+    path-to-regexp "0.1.7"
+    proxy-addr "~2.0.2"
+    qs "6.5.1"
+    range-parser "~1.2.0"
+    safe-buffer "5.1.1"
+    send "0.16.1"
+    serve-static "1.13.1"
+    setprototypeof "1.1.0"
+    statuses "~1.3.1"
+    type-is "~1.6.15"
+    utils-merge "1.0.1"
+    vary "~1.1.2"
+
+extend@^3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
+extend@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-2.0.1.tgz#1ee8010689e7395ff9448241c98652bc759a8260"
+
 external-editor@^2.0.4:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.1.0.tgz#3d026a21b7f95b5726387d4200ac160d372c3b48"
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
   dependencies:
     chardet "^0.4.0"
     iconv-lite "^0.4.17"
     tmp "^0.0.33"
 
+extsprintf@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
+
+extsprintf@^1.2.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
+
 fast-deep-equal@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
+
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
@@ -530,6 +754,18 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
+finalhandler@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.0.tgz#ce0b6855b45853e791b2fcc680046d88253dd7f5"
+  dependencies:
+    debug "2.6.9"
+    encodeurl "~1.0.1"
+    escape-html "~1.0.3"
+    on-finished "~2.3.0"
+    parseurl "~1.3.2"
+    statuses "~1.3.1"
+    unpipe "~1.0.0"
+
 flat-cache@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.0.tgz#d3030b32b38154f4e3b7e9c709f490f7ef97c481"
@@ -539,11 +775,19 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-fn.name@1.0.x:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.0.1.tgz#8015ad149c1011a116cdb89eba4cc11d9039add8"
+fn.name@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
 
-form-data@^2.3.1:
+foreachasync@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/foreachasync/-/foreachasync-3.0.0.tgz#5502987dc8714be3392097f32e0071c9dee07cf6"
+
+forever-agent@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
+
+form-data@^2.3.1, form-data@~2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
   dependencies:
@@ -551,9 +795,17 @@ form-data@^2.3.1:
     combined-stream "1.0.6"
     mime-types "^2.1.12"
 
-formidable@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.1.1.tgz#96b8886f7c3c3508b932d6bd70c4d3a88f35f1a9"
+formidable@^1.1.1, formidable@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
+
+forwarded@~0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
+
+fresh@0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -563,12 +815,22 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
 
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+
 get-stream@^2.0.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-2.3.1.tgz#5f38f93f346009666ee0150a054167f91bdd95de"
   dependencies:
     object-assign "^4.0.1"
     pinkie-promise "^2.0.0"
+
+getpass@^0.1.1:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
+  dependencies:
+    assert-plus "^1.0.0"
 
 glob@7.1.2, glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
   version "7.1.2"
@@ -582,8 +844,8 @@ glob@7.1.2, glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
     path-is-absolute "^1.0.0"
 
 globals@^11.0.1:
-  version "11.3.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.3.0.tgz#e04fdb7b9796d8adac9c8f64c14837b2313378b0"
+  version "11.7.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.7.0.tgz#a583faa43055b1aca771914bf68258e2fc125673"
 
 globby@^5.0.0:
   version "5.0.0"
@@ -620,9 +882,20 @@ graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
-growl@1.10.3:
-  version "1.10.3"
-  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.3.tgz#1926ba90cf3edfe2adb4927f5880bc22c66c790f"
+growl@1.10.5:
+  version "1.10.5"
+  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
+
+har-schema@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
+
+har-validator@~5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.0.3.tgz#ba402c266194f15956ef15e0fcf242993f6a7dfd"
+  dependencies:
+    ajv "^5.1.0"
+    har-schema "^2.0.0"
 
 has-ansi@^2.0.0:
   version "2.0.0"
@@ -630,9 +903,18 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
-has-flag@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
+hawk@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/hawk/-/hawk-2.3.0.tgz#20864369707c2264bb823d1c4172acd5d77ed509"
+  dependencies:
+    boom "2.x.x"
+    cryptiles "2.x.x"
+    hoek "2.x.x"
+    sntp "1.x.x"
 
 hawk@^6.0.2:
   version "6.0.2"
@@ -643,25 +925,78 @@ hawk@^6.0.2:
     hoek "4.x.x"
     sntp "2.x.x"
 
+hawk@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/hawk/-/hawk-1.0.0.tgz#b90bb169807285411da7ffcb8dd2598502d3b52d"
+  dependencies:
+    boom "0.4.x"
+    cryptiles "0.2.x"
+    hoek "0.9.x"
+    sntp "0.2.x"
+
 he@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
+
+hoek@0.9.x:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/hoek/-/hoek-0.9.1.tgz#3d322462badf07716ea7eb85baf88079cddce505"
+
+hoek@2.x.x:
+  version "2.16.3"
+  resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
 hoek@4.x.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
 
-iconv-lite@^0.4.17:
+http-errors@1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.2.tgz#0a002cc85707192a7e7946ceedc11155f60ec736"
+  dependencies:
+    depd "1.1.1"
+    inherits "2.0.3"
+    setprototypeof "1.0.3"
+    statuses ">= 1.3.1 < 2"
+
+http-errors@~1.6.2:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.3"
+    setprototypeof "1.1.0"
+    statuses ">= 1.4.0 < 2"
+
+http-signature@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
+  dependencies:
+    assert-plus "^1.0.0"
+    jsprim "^1.2.2"
+    sshpk "^1.7.0"
+
+iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
-ieee754@^1.1.4:
+iconv-lite@^0.4.17:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
+
+ieee754@1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
 
+ieee754@^1.1.4:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.12.tgz#50bf24e5b9c8bb98af4964c941cdb0918da7b60b"
+
 ignore@^3.3.3:
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -674,7 +1009,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.3, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -697,9 +1032,17 @@ inquirer@^3.0.6:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
+ipaddr.js@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.6.0.tgz#e3fa357b773da619f26e95f049d055c72796f86b"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
+
+is-buffer@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
 
 is-buffer@~1.1.1:
   version "1.1.6"
@@ -709,13 +1052,17 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
 
+is-node@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-node/-/is-node-1.0.2.tgz#d7d002745ef7debbb7477e988956ab0a4fccb653"
+
 is-path-cwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
 
 is-path-in-cwd@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz#6477582b8214d602346094567003be8a9eac04dc"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz#5ac48b345ef675339bd6c7a48a912110b241cf52"
   dependencies:
     is-path-inside "^1.0.0"
 
@@ -745,6 +1092,10 @@ is-stream@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
+is-typedarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
@@ -757,6 +1108,10 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
+isstream@~0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+
 jmespath@0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
@@ -765,20 +1120,36 @@ js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.9.1:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
+js-yaml@^3.10.0, js-yaml@^3.9.1:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+jsbn@~0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
 json-schema-traverse@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
 
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+
+json-schema@0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
+
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
 jsonwebtoken@^5.7.0:
   version "5.7.0"
@@ -788,22 +1159,33 @@ jsonwebtoken@^5.7.0:
     ms "^0.7.1"
     xtend "^4.0.1"
 
-jwa@^1.1.4:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.1.5.tgz#a0552ce0220742cd52e153774a32905c30e756e5"
+jsprim@^1.2.2:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
   dependencies:
-    base64url "2.0.0"
+    assert-plus "1.0.0"
+    extsprintf "1.3.0"
+    json-schema "0.2.3"
+    verror "1.10.0"
+
+jwa@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.1.6.tgz#87240e76c9808dbde18783cf2264ef4929ee50e6"
+  dependencies:
     buffer-equal-constant-time "1.0.1"
-    ecdsa-sig-formatter "1.0.9"
+    ecdsa-sig-formatter "1.0.10"
     safe-buffer "^5.0.1"
 
 jws@^3.0.0:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/jws/-/jws-3.1.4.tgz#f9e8b9338e8a847277d6444b1464f61880e050a2"
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.1.5.tgz#80d12d05b293d1e841e7cb8b4e69e561adcf834f"
   dependencies:
-    base64url "^2.0.0"
-    jwa "^1.1.4"
+    jwa "^1.1.5"
     safe-buffer "^5.0.1"
+
+left-pad@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
 
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
@@ -812,17 +1194,21 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lodash@^4.0.0, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.5.1:
-  version "4.17.5"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+lodash@4.17.4:
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@^4.5.1:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
 lowercase-keys@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
 
 lru-cache@^4.0.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
@@ -835,7 +1221,15 @@ md5@^2.2.1:
     crypt "~0.0.1"
     is-buffer "~1.1.1"
 
-methods@^1.1.1:
+media-typer@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
+
+merge-descriptors@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
+
+methods@^1.1.1, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
@@ -843,11 +1237,15 @@ mime-db@~1.33.0:
   version "1.33.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
 
-mime-types@^2.1.12:
+mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.18:
   version "2.1.18"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   dependencies:
     mime-db "~1.33.0"
+
+mime@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
 
 mime@^1.4.1:
   version "1.6.0"
@@ -857,7 +1255,7 @@ mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
 
-minimatch@^3.0.2, minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -867,26 +1265,27 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-mkdirp@0.5.1, mkdirp@^0.5.1:
+mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
 
-mocha@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.0.0.tgz#cccac988b0bc5477119cba0e43de7af6d6ad8f4e"
+mocha@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.2.0.tgz#6d8ae508f59167f940f2b5b3c4a612ae50c90ae6"
   dependencies:
-    browser-stdout "1.3.0"
-    commander "2.11.0"
+    browser-stdout "1.3.1"
+    commander "2.15.1"
     debug "3.1.0"
-    diff "3.3.1"
+    diff "3.5.0"
     escape-string-regexp "1.0.5"
     glob "7.1.2"
-    growl "1.10.3"
+    growl "1.10.5"
     he "1.1.1"
+    minimatch "3.0.4"
     mkdirp "0.5.1"
-    supports-color "4.4.0"
+    supports-color "5.4.0"
 
 ms@2.0.0:
   version "2.0.0"
@@ -900,25 +1299,53 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-nan@^2.0.9:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.9.2.tgz#f564d75f5f8f36a6d9456cca7a6c4fe488ab7866"
-
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+negotiator@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
+
+nock@^9.0.27:
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-9.4.2.tgz#bab58a44b5781bdb74d7808673a2dbeefafb898d"
+  dependencies:
+    chai "^4.1.2"
+    debug "^3.1.0"
+    deep-equal "^1.0.0"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.5"
+    mkdirp "^0.5.0"
+    propagate "^1.0.0"
+    qs "^6.5.1"
+    semver "^5.5.0"
 
 node-status-codes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-status-codes/-/node-status-codes-1.0.0.tgz#5ae5541d024645d32a58fcddc9ceecea7ae3ac2f"
 
+node-uuid@~1.4.1:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
+
+oauth-sign@~0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
+
 object-assign@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
-object-inspect@1.0.x:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.0.2.tgz#a97885b553e575eb4009ebc09bdda9b1cd21979a"
+object-inspect@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b"
+
+on-finished@~2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
+  dependencies:
+    ee-first "1.1.1"
 
 once@^1.3.0:
   version "1.4.0"
@@ -953,6 +1380,10 @@ parse-json@^2.1.0:
   dependencies:
     error-ex "^1.2.0"
 
+parseurl@~1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
@@ -961,9 +1392,17 @@ path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
-pathval@0.1.x:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/pathval/-/pathval-0.1.1.tgz#08f911cdca9cce5942880da7817bc0b723b66d82"
+path-to-regexp@0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
+
+pathval@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
+
+performance-now@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
 
 pify@^2.0.0:
   version "2.3.0"
@@ -991,10 +1430,6 @@ prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
 
-process-nextick-args@~1.0.6:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
-
 process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
@@ -1003,21 +1438,33 @@ progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
-promise@^7.1.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
-  dependencies:
-    asap "~2.0.3"
-
 promise@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-8.0.1.tgz#e45d68b00a17647b6da711bf85ed6ed47208f450"
   dependencies:
     asap "~2.0.3"
 
-pruddy-error@1.0.x:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/pruddy-error/-/pruddy-error-1.0.2.tgz#b37ec1a38bf9107c0cdc5bc663d3d4e80354ae80"
+propagate@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-1.0.0.tgz#00c2daeedda20e87e3782b344adba1cddd6ad709"
+
+propget@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/propget/-/propget-1.1.0.tgz#6c1c7ac9a09c05bdb5c967f0cd8e1c09409fef6b"
+
+proxy-addr@~2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.3.tgz#355f262505a621646b3130a728eb647e22055341"
+  dependencies:
+    forwarded "~0.1.2"
+    ipaddr.js "1.6.0"
+
+pruddy-error@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/pruddy-error/-/pruddy-error-2.0.2.tgz#0507d7a8ccc0ff7e497fa780201c9727b302181c"
+  dependencies:
+    is-node "^1.0.2"
+    left-pad "^1.2.0"
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -1027,23 +1474,52 @@ punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
 
-qs@^6.5.1:
+punycode@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+
+punycode@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+
+qs@6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
+
+qs@^0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-0.6.6.tgz#6e015098ff51968b8a3c819001d5f2c89bc4b107"
+
+qs@^6.5.1, qs@~6.5.1:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
 querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
+range-parser@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
+
 raven@^2.2.1:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/raven/-/raven-2.4.2.tgz#0129e2adc30788646fd530b67d08a8ce25d4f6dc"
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/raven/-/raven-2.6.3.tgz#207475a12809277ef54eaceafe2597ff65262ab4"
   dependencies:
     cookie "0.3.1"
     md5 "^2.2.1"
-    stack-trace "0.0.9"
+    stack-trace "0.0.10"
     timed-out "4.0.1"
     uuid "3.0.0"
+
+raw-body@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.2.tgz#bcd60c77d3eb93cde0050295c3f379389bc88f89"
+  dependencies:
+    bytes "3.0.0"
+    http-errors "1.6.2"
+    iconv-lite "0.4.19"
+    unpipe "1.0.0"
 
 read-all-stream@^3.0.0:
   version "3.1.0"
@@ -1061,33 +1537,46 @@ read-all-stream@^3.0.0:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.4.tgz#c946c3f47fa7d8eabc0b6150f4a12f69a4574071"
+readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.2.2, readable-stream@^2.3.5:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
     isarray "~1.0.0"
     process-nextick-args "~2.0.0"
     safe-buffer "~5.1.1"
-    string_decoder "~1.0.3"
+    string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^2.2.2:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
+regexpp@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-1.1.0.tgz#0e3516dd0b7904f413d2d4193dce4618c3a689ab"
+
+request@^2.81.0:
+  version "2.87.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
   dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.0.3"
-    util-deprecate "~1.0.1"
-
-regenerator-runtime@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+    aws-sign2 "~0.7.0"
+    aws4 "^1.6.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.1"
+    forever-agent "~0.6.1"
+    form-data "~2.3.1"
+    har-validator "~5.0.3"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.17"
+    oauth-sign "~0.8.2"
+    performance-now "^2.1.0"
+    qs "~6.5.1"
+    safe-buffer "^5.1.1"
+    tough-cookie "~2.3.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.1.0"
 
 require-uncached@^1.0.3:
   version "1.0.3"
@@ -1107,7 +1596,7 @@ restore-cursor@^2.0.0:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
 
-rimraf@^2.2.8:
+rimraf@^2.2.8, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
@@ -1129,9 +1618,17 @@ rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
-safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+
+safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+
+"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
 sax@1.2.1:
   version "1.2.1"
@@ -1141,9 +1638,44 @@ sax@>=0.6.0:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
-semver@^5.3.0:
+semver@^5.3.0, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
+send@0.16.1:
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.16.1.tgz#a70e1ca21d1382c11d0d9f6231deb281080d7ab3"
+  dependencies:
+    debug "2.6.9"
+    depd "~1.1.1"
+    destroy "~1.0.4"
+    encodeurl "~1.0.1"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    fresh "0.5.2"
+    http-errors "~1.6.2"
+    mime "1.4.1"
+    ms "2.0.0"
+    on-finished "~2.3.0"
+    range-parser "~1.2.0"
+    statuses "~1.3.1"
+
+serve-static@1.13.1:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.13.1.tgz#4c57d53404a761d8f2e7c1e8a18a47dbf278a719"
+  dependencies:
+    encodeurl "~1.0.1"
+    escape-html "~1.0.3"
+    parseurl "~1.3.2"
+    send "0.16.1"
+
+setprototypeof@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
+
+setprototypeof@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -1165,7 +1697,7 @@ slice-ansi@1.0.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
 
-slugid@^1.1.0:
+slugid@^1.0.3, slugid@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/slugid/-/slugid-1.1.0.tgz#e09f00899c09f5a7058edc36dd49f046fd50a82a"
   dependencies:
@@ -1178,6 +1710,18 @@ slugid@^2.0.0:
     uuid "^3.2.1"
     uuid-parse "^1.0.0"
 
+sntp@0.2.x:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/sntp/-/sntp-0.2.4.tgz#fb885f18b0f3aad189f824862536bceeec750900"
+  dependencies:
+    hoek "0.9.x"
+
+sntp@1.x.x:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
+  dependencies:
+    hoek "2.x.x"
+
 sntp@2.x.x:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/sntp/-/sntp-2.1.0.tgz#2c6cec14fedc2222739caf9b5c3d85d1cc5a2cc8"
@@ -1188,23 +1732,44 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
-stack-trace@0.0.9:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.9.tgz#a8f6eaeca90674c333e7c43953f275b451510695"
-
-statsum@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/statsum/-/statsum-0.5.1.tgz#6c2876bd11f0fc4f652295107259d9936760c209"
+sshpk@^1.7.0:
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.14.2.tgz#c6fc61648a3d9c4e764fd3fcdf4ea105e492ba98"
   dependencies:
-    babel-runtime "^6.0.0"
+    asn1 "~0.2.3"
+    assert-plus "^1.0.0"
+    dashdash "^1.12.0"
+    getpass "^0.1.1"
+    safer-buffer "^2.0.2"
+  optionalDependencies:
+    bcrypt-pbkdf "^1.0.0"
+    ecc-jsbn "~0.1.1"
+    jsbn "~0.1.0"
+    tweetnacl "~0.14.0"
+
+stack-trace@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+
+statsum@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/statsum/-/statsum-0.6.0.tgz#1b19566459b43885aee23d744f41295c7c5c80ad"
+  dependencies:
     debug "^2.2.0"
     get-stream "^2.0.0"
     got "^5.0.0"
     jsonwebtoken "^5.7.0"
     lodash "^4.5.1"
-    promise "^7.1.1"
-    url-join "^0.0.1"
+    urljoin "^0.1.5"
     uuid "^2.0.2"
+
+"statuses@>= 1.3.1 < 2", "statuses@>= 1.4.0 < 2":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
+
+statuses@~1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
 
 string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
@@ -1217,9 +1782,9 @@ string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
-string_decoder@~1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
   dependencies:
     safe-buffer "~5.1.0"
 
@@ -1239,7 +1804,14 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-superagent@~3.8.1:
+superagent-hawk@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/superagent-hawk/-/superagent-hawk-0.0.6.tgz#0cfb70e21546e3a3e902da208a28edd965f82dab"
+  dependencies:
+    hawk "~1.0.0"
+    qs "^0.6.6"
+
+superagent@3.8.2:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.2.tgz#e4a11b9d047f7d3efeb3bbe536d9ec0021d16403"
   dependencies:
@@ -1254,23 +1826,32 @@ superagent@~3.8.1:
     qs "^6.5.1"
     readable-stream "^2.0.5"
 
-supports-color@4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.4.0.tgz#883f7ddabc165142b2a61427f3352ded195d1a3e"
+superagent@~3.8.1:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.3.tgz#460ea0dbdb7d5b11bc4f78deba565f86a178e128"
   dependencies:
-    has-flag "^2.0.0"
+    component-emitter "^1.2.0"
+    cookiejar "^2.1.0"
+    debug "^3.1.0"
+    extend "^3.0.0"
+    form-data "^2.3.1"
+    formidable "^1.2.0"
+    methods "^1.1.1"
+    mime "^1.4.1"
+    qs "^6.5.1"
+    readable-stream "^2.3.5"
+
+supports-color@5.4.0, supports-color@^5.3.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
+  dependencies:
+    has-flag "^3.0.0"
 
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^4.0.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
-  dependencies:
-    has-flag "^2.0.0"
-
-table@^4.0.1:
+table@4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/table/-/table-4.0.2.tgz#a33447375391e766ad34d3486e6e2aedc84d2e36"
   dependencies:
@@ -1281,32 +1862,76 @@ table@^4.0.1:
     slice-ansi "1.0.0"
     string-width "^2.1.1"
 
-taskcluster-client@^3.0.3:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/taskcluster-client/-/taskcluster-client-3.2.1.tgz#60d6c2dd111e13501e775b92dd5d8398566f7cb3"
+taskcluster-client@10.0.0, taskcluster-client@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/taskcluster-client/-/taskcluster-client-10.0.0.tgz#4acc66797897a6a922b9c9ec2c87ddebd884cedd"
   dependencies:
     amqplib "^0.5.1"
-    babel-runtime "^6.26.0"
     debug "^3.1.0"
     hawk "^6.0.2"
     lodash "^4.17.4"
     promise "^8.0.1"
     slugid "^1.1.0"
     superagent "~3.8.1"
+    taskcluster-lib-urls "^1.1.0"
 
-taskcluster-lib-monitor@^5.1.5:
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/taskcluster-lib-monitor/-/taskcluster-lib-monitor-5.1.5.tgz#bbe229e4f6b566972b733c561706050184281a06"
+taskcluster-lib-monitor@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/taskcluster-lib-monitor/-/taskcluster-lib-monitor-10.0.0.tgz#85dc2ca71a388ac58100bf26392930ea98a0c752"
   dependencies:
+    app-root-dir "^1.0.2"
     aws-sdk "^2.30.0"
-    babel-runtime "^6.26.0"
     bluebird "^3.5.1"
     debug "^3.1.0"
     lodash "^4.5.1"
     raven "^2.2.1"
-    statsum "^0.5.1"
-    taskcluster-client "^3.0.3"
-    usage "^0.7.1"
+    statsum "^0.6.0"
+    taskcluster-client "^10.0.0"
+
+taskcluster-lib-testing@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/taskcluster-lib-testing/-/taskcluster-lib-testing-12.1.0.tgz#27fb0ca2734c54e425dc48d99b43fd0d4068e70a"
+  dependencies:
+    aws-sdk "^2.144.0"
+    azure-table-node "1.5.0"
+    debug "^3.1.0"
+    express "4.16.2"
+    express-sslify "1.2.0"
+    hawk "2.3.0"
+    lodash "4.17.4"
+    nock "^9.0.27"
+    promise "^8.0.1"
+    slugid "^1.0.3"
+    superagent "3.8.2"
+    superagent-hawk "0.0.6"
+    taskcluster-client "10.0.0"
+    taskcluster-lib-urls "^10.0.0"
+    taskcluster-lib-validate "^11.0.1"
+    uuid "^3.1.0"
+
+taskcluster-lib-urls@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/taskcluster-lib-urls/-/taskcluster-lib-urls-1.1.0.tgz#de6d78a0b61179e7f395ef2d3d7e5a994c1a6446"
+
+taskcluster-lib-urls@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/taskcluster-lib-urls/-/taskcluster-lib-urls-10.0.0.tgz#ee4c687b4539171d8aef39b38a63c8b9bc82f82e"
+
+taskcluster-lib-validate@^11.0.1, taskcluster-lib-validate@^11.0.2:
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/taskcluster-lib-validate/-/taskcluster-lib-validate-11.0.2.tgz#e1270450c9f1e09ddd8ba2cb6be1123eac86a3a6"
+  dependencies:
+    ajv "^6.5.0"
+    app-root-dir "^1.0.2"
+    aws-sdk "^2.142.0"
+    debug "^3.1.0"
+    js-yaml "^3.10.0"
+    lodash "^4.5.1"
+    mkdirp "^0.5.1"
+    promise "^8.0.1"
+    rimraf "^2.6.2"
+    taskcluster-lib-urls "^1.1.0"
+    walk "^2.3.9"
 
 text-table@~0.2.0:
   version "0.2.0"
@@ -1330,27 +1955,56 @@ tmp@^0.0.33:
   dependencies:
     os-tmpdir "~1.0.2"
 
+tough-cookie@~2.3.3:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
+  dependencies:
+    punycode "^1.4.1"
+
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  dependencies:
+    safe-buffer "^5.0.1"
+
+tweetnacl@^0.14.3, tweetnacl@~0.14.0:
+  version "0.14.5"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
+
 type-check@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
 
-type-detect@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-0.1.1.tgz#0ba5ec2a885640e470ea4e8505971900dac58822"
+type-detect@^4.0.0:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+
+type-is@~1.6.15:
+  version "1.6.16"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.16.tgz#f89ce341541c672b25ee7ae3c73dee3b2be50194"
+  dependencies:
+    media-typer "0.3.0"
+    mime-types "~2.1.18"
 
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+unpipe@1.0.0, unpipe@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+
 unzip-response@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-1.0.2.tgz#b984f0877fc0a89c2c773cc1ef7b5b232b5b06fe"
 
-url-join@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/url-join/-/url-join-0.0.1.tgz#1db48ad422d3402469a87f7d97bdebfe4fb1e3c8"
+uri-js@^4.2.1:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
+  dependencies:
+    punycode "^2.1.0"
 
 url-parse-lax@^1.0.0:
   version "1.0.0"
@@ -1365,16 +2019,19 @@ url@0.10.3:
     punycode "1.3.2"
     querystring "0.2.0"
 
-usage@^0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/usage/-/usage-0.7.1.tgz#25f3106a519550aba41bf6e7685bc9bd533362ff"
+urljoin@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/urljoin/-/urljoin-0.1.5.tgz#b25d2c6112c55ac9d50096a49a0f1fb7f4f53921"
   dependencies:
-    bindings "1.x.x"
-    nan "^2.0.9"
+    extend "~2.0.0"
 
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+
+utils-merge@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
 
 uuid-parse@^1.0.0:
   version "1.0.0"
@@ -1392,13 +2049,31 @@ uuid@^2.0.1, uuid@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
-uuid@^3.2.1:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.0.tgz#b237147804881d7b86f40a7ff8f590f15c37de32"
+uuid@^3.1.0, uuid@^3.2.1:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+
+vary@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
+
+verror@1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
+  dependencies:
+    assert-plus "^1.0.0"
+    core-util-is "1.0.2"
+    extsprintf "^1.2.0"
+
+walk@^2.3.9:
+  version "2.3.14"
+  resolved "https://registry.yarnpkg.com/walk/-/walk-2.3.14.tgz#60ec8631cfd23276ae1e7363ce11d626452e1ef3"
+  dependencies:
+    foreachasync "^3.0.0"
 
 which@^1.2.9:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   dependencies:
     isexe "^2.0.0"
 
@@ -1416,18 +2091,16 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
-xml2js@0.4.17:
-  version "0.4.17"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.17.tgz#17be93eaae3f3b779359c795b419705a8817e868"
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
   dependencies:
     sax ">=0.6.0"
-    xmlbuilder "^4.1.0"
+    xmlbuilder "~9.0.1"
 
-xmlbuilder@4.2.1, xmlbuilder@^4.1.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-4.2.1.tgz#aa58a3041a066f90eaa16c2f5389ff19f3f461a5"
-  dependencies:
-    lodash "^4.0.0"
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
 
 xtend@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
This adds a new `Exchanges` class which can produce a publisher with the
`publisher` method.  The publisher is resilient to reconnections and
will retry sending until a given deadline.

I've tried to make this act a bit similar to tc-lib-api.  And there's a "fake" mode to support testing.

It's also worth noting that while this does perform validation of messages, it does not depend on tc-lib-validate or Ajv -- it's up to the caller to pass a schemaset.  So if you only want to use this library to consume messages, you can avoid the 35MB of JS that Ajv brings with it.