### PR TITLE
Bug 1490456 - bug fixes in recycling timing

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -61,10 +61,6 @@ class Client extends events.EventEmitter {
     this.debug('starting');
     this.running = true;
     this.recycle();
-
-    this._interval = setInterval(
-      () => this.recycle(),
-      this._recycleInterval);
   }
 
   async stop() {
@@ -73,8 +69,6 @@ class Client extends events.EventEmitter {
     this.running = false;
     clearTimeout(this._recycleTimer);
     this._recycleTimer = null;
-    clearInterval(this._interval);
-    this._interval = null;
 
     this.recycle();
 
@@ -98,28 +92,7 @@ class Client extends events.EventEmitter {
     }
 
     if (this.running) {
-      const newConn = new Connection(this._retirementDelay);
-
-      // don't actually start connecting until at least minReconnectionInterval has passed
-      const earliestConnectionTime = this.lastConnectionTime + this._minReconnectionInterval;
-      const now = new Date().getTime();
-      setTimeout(async () => {
-        if (newConn.state !== 'waiting') {
-          // the connection is no longer waiting, so don't proceed with
-          // connecting (this is rare, but can occur if the recycle timer
-          // occurs at just the wrong moment)
-          return;
-        }
-
-        try {
-          this.lastConnectionTime = new Date().getTime();
-          const connectionString = await this._fetchCredentials();
-          newConn.connect(connectionString);
-        } catch (err) {
-          this.debug(`Error while fetching credentials: ${err}`);
-          newConn.failed();
-        }
-      }, now < earliestConnectionTime ? earliestConnectionTime - now : 0);    
+      const newConn = this._startConnection();
 
       newConn.once('connected', () => {
         this.emit('connected', newConn);
@@ -132,6 +105,34 @@ class Client extends events.EventEmitter {
       });
       this.connections.unshift(newConn);
     }
+  }
+
+  _startConnection() {
+    const newConn = new Connection(this._retirementDelay);
+
+    // don't actually start connecting until at least minReconnectionInterval has passed
+    const earliestConnectionTime = this.lastConnectionTime + this._minReconnectionInterval;
+    const now = new Date().getTime();
+    setTimeout(async () => {
+      if (newConn.state !== 'waiting') {
+        // the connection is no longer waiting, so don't proceed with
+        // connecting (this is rare, but can occur if the recycle timer
+        // occurs at just the wrong moment)
+        return;
+      }
+
+      try {
+        this.lastConnectionTime = new Date().getTime();
+        const {connectionString, recycleAt} = await this.credentials();
+        this._updateRecycleTimer(recycleAt);
+        newConn.connect(connectionString);
+      } catch (err) {
+        this.debug(`Error while fetching credentials: ${err}`);
+        newConn.failed();
+      }
+    }, now < earliestConnectionTime ? earliestConnectionTime - now : 0);
+
+    return newConn;
   }
 
   /**
@@ -216,28 +217,15 @@ class Client extends events.EventEmitter {
   }
 
   /**
-   * Using credentials return connectionstring  and set _recycleAfter of client.
-   * recycleAfter is the recycle interval which may be suggested by the service from which 
-   * credentials are claimed
+   * Update the _recycleTimer, either to expire at recycleAt or, if that's omitted,
+   * after recycleInterval.
    */
-  async _fetchCredentials() {
-    const {connectionString, recycleAt} = await this.credentials();
-    if (recycleAt) {
-      this._recycleAfter = recycleAt - new Date();
-      this._recycleTimer = setTimeout(() => this.recycle(), this._recycleAfter);
-      if (this._interval) {
-        clearInterval(this._interval);
-        this._interval = null;
-        this._recycleInterval = null;
-      }
+  async _updateRecycleTimer(recycleAt) {
+    const recycleAfter = recycleAt ?  recycleAt - new Date() : this._recycleInterval;
+    if (this._recycleTimer) {
+      clearTimeout(this._recycleTimer);
     }
-    
-    if (!recycleAt && !this._interval) {
-      // If recycleAt doesn't provide a value previous value is used
-      this._recycleTimer = setTimeout(() => this.recycle(), this._recycleAfter);
-    }
-
-    return connectionString;
+    this._recycleTimer = setTimeout(() => this.recycle(), recycleAfter);
   }
 }
 

--- a/src/credentials.js
+++ b/src/credentials.js
@@ -71,7 +71,7 @@ const claimedCredentials = ({rootUrl, credentials, namespace, expiresAfter, cont
       contact,
     });
     connectionString = res.connectionString;
-    recycleAt = res.reclaimAt;
+    recycleAt = new Date(res.reclaimAt);
     return {connectionString, recycleAt};
   };
 };
@@ -87,7 +87,7 @@ const mockClaimedCredentials = (connectionString, recycleAt) => {
   recycleAfter = recycleAt || taskcluster.fromNow('5 seconds');
 
   return async () => {
-    return {connectionString, recycleAt};
+    return {connectionString, recycleAt: new Date(recycleAt)};
   };
 };
 

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -1,4 +1,5 @@
 const {Client, connectionStringCredentials} = require('../src');
+const {Connection} = require('../src/client');
 const amqplib = require('amqplib');
 const assume = require('assume');
 const debugModule = require('debug');
@@ -84,24 +85,50 @@ const connectionTests = connectionString => {
     assume(client.activeConnection).to.equal(undefined);
   });
 
-  test('recycle interval', async function() {
+  test('recycle interval (no recycleAt)', async function() {
     let recycles = 0;
-    const oldMethod = Client.prototype.recycle;
-    Client.prototype.recycle = () => { recycles++; };
-    try {
-      const client = new Client({
-        credentials,
-        recycleInterval: 10,
-        retirementDelay: 50,
-        monitor,
-        namespace: 'guest',
-      });
-      await new Promise(resolve => setTimeout(resolve, 100));
-      await client.stop();
-      assume(recycles).is.gt(5);
-    } finally {
-      Client.prototype.recycle = oldMethod;
-    }
+    const client = new Client({
+      credentials,
+      recycleInterval: 10,
+      retirementDelay: 50,
+      monitor,
+      namespace: 'guest',
+    });
+
+    // simplify _startConnection to the important part for this test:
+    // updating the timer (and counting calls)
+    client._startConnection = () => {
+      recycles++;
+      client._updateRecycleTimer();
+      return new Connection(50);
+    };
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+    await client.stop();
+    assume(recycles).is.gt(5);
+  });
+
+  test('recycle interval (with recycleAt)', async function() {
+    let recycles = 0;
+    const client = new Client({
+      credentials,
+      recycleInterval: 10,
+      retirementDelay: 50,
+      monitor,
+      namespace: 'guest',
+    });
+
+    // simplify _startConnection to the important part for this test:
+    // updating the timer (and counting calls)
+    client._startConnection = () => {
+      recycles++;
+      client._updateRecycleTimer(new Date(new Date().getTime() + 10));
+      return new Connection(50);
+    };
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+    await client.stop();
+    assume(recycles).is.gt(5);
   });
 
   test('minReconnectionInterval', async function() {

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -115,7 +115,7 @@ const connectionTests = connectionString => {
     const client = new Client({
       credentials,
       retirementDelay: 50,
-      minReconnectionInterval: 20,
+      minReconnectionInterval: 10,
       monitor,
       namespace: 'guest',
     });


### PR DESCRIPTION
The first commit is pretty straightforward; the second is a more substantial refactor of timer handling.  I recognize that it changes the behavior a little bit, in that it completely ignores recycleInterval when using a credentials function that returns recycleAt, but I think that's OK -- the idea of recycleInterval is just to make sure we don't stay connected forever, and recycleAt accomplishes that goal too.