### PR TITLE
Routing key constant as boolean

### DIFF
--- a/src/publisher.js
+++ b/src/publisher.js
@@ -98,7 +98,7 @@ class Entry {
       routingKey: this.routingKey.map(key => ({
         name: key.name,
         summary: key.summary,
-        constant: !!key.constant,
+        constant: key.constant,
         multipleWords: key.multipleWords,
         required: key.required,
       })),


### PR DESCRIPTION
...messes up my tests. Instead of
```javascript
{
  name: 'routingKeyKind',
  summary: 'Identifier for the routing-key kind. This is always `"primary"` for the formalized routing key.',
  constant: 'primary',
  multipleWords: false,
  required: true
}
```

I am getting

```javascript
{
  name: 'routingKeyKind',
  summary: 'Identifier for the routing-key kind. This is always `"primary"` for the formalized routing key.',
  constant: true,
  multipleWords: undefined,
  required: true
}
```
I must confess, I don't understand this line... so what I'm suggesting in this PR may be too simple a remedy for the problem... Maybe we need some sort of clever ternary in there?

I also see `multipleWords` turning to `undefined` there... not sure how I feel about that... 🤔