### PR TITLE
Don't report IllegalOperationError

### DIFF
--- a/src/consumer.js
+++ b/src/consumer.js
@@ -161,11 +161,15 @@ class PulseConsumer {
           channel.ack(msg);
         } catch (err) {
           // the error handling in the inner try block went badly, so this
-          // channel is probably sick
-          this.client.monitor.reportError(err, {
-            queueName,
-            exchange: msg.exchange,
-          });
+          // channel is probably sick; but if this is an IllegalOperationError,
+          // there's no need to report it (that is basically saying the channel
+          // has closed, so we'll re-connect)
+          if (!err instanceof amqplib.IllegalOperationError) {
+            this.client.monitor.reportError(err, {
+              queueName,
+              exchange: msg.exchange,
+            });
+          }
           conn.failed();
         } finally {
           this.processingMessages--;


### PR DESCRIPTION
This is an "expected" error and we react to it by marking the connection
as failed and re-connecting.

https://sentry.prod.mozaws.net/operations/taskcluster-treeherder/issues/4871187/