### PR TITLE
Bug 1508849 - ensure that routingKey.required is present

### DIFF
--- a/src/publisher.js
+++ b/src/publisher.js
@@ -100,7 +100,7 @@ class Entry {
         summary: key.summary,
         constant: key.constant,
         multipleWords: Boolean(key.multipleWords),
-        required: key.required,
+        required: Boolean(key.required),
       })),
     };
   }


### PR DESCRIPTION
Fixes validation errors like

```
auth/references/events.json: reference.entries[2].routingKey[0] should have required property 'required'
```